### PR TITLE
fix bugs

### DIFF
--- a/kqueue/kqueue.go
+++ b/kqueue/kqueue.go
@@ -95,6 +95,7 @@ func (eventLoop *EventLoop) Handle(handler Handler) {
 					log.Println("Failed to create Socket for connecting to client:", err)
 					continue
 				}
+				syscall.SetNonblock(socketConnection, true)
 				log.Print("Accepted new connection ", socketConnection, " from ", eventFileDescriptor)
 
 				/*

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"log"
 	"os"
-	"strings"
 )
 
 func main() {
@@ -25,14 +24,8 @@ func main() {
 	log.Println("Server started. Waiting for incoming connections. ^C to exit.")
 	eventLoop.Handle(func(s *socket.Socket) {
 		reader := bufio.NewReader(s)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil || strings.TrimSpace(line) == "" {
-				break
-			}
-			log.Print("Read on ", s, ": ", line)
-			s.Write([]byte(line))
-		}
-		s.Close()
+		line, _ := reader.ReadString('\n')
+		log.Print("Read on ", s, ": ", line)
+		s.Write([]byte(line))
 	})
 }


### PR DESCRIPTION
Hi！

I run your example program of kqueue in Go，and found some bugs.

Sharing my idea with you here.

First, after the kqueue server started, i connect to localhost:8080 by telnet, first connection is OK, kqueue server is correctly accept first connection and echo the msg. But new another connection at the same time, you can see that kqueue server do not accept the connection at all.

The cause of first bug is that you do not set connection to **non-blocking** after accept, so your code is running in **blocking mode** and one connection block all other connection, corresponding code is in **kqueue.go -> Handle( )**

But when i set connection to **non-blocking** after connection accepted, another problem comes. After first echo, connection is closed, after debuging, i found that you use a for loop in your user-define **handler func**, you do not need to do so, because epoll/kqueue is event-drive, it will handler the read/write event in event loop, you just need to handle the event once then return, do not need to wait for data in loop again, corresponding code is in **main.go**

